### PR TITLE
Set expand=True on sections for Slack Message

### DIFF
--- a/find_flaky_tests.py
+++ b/find_flaky_tests.py
@@ -153,7 +153,8 @@ def print_for_slack(occurrences: List[Occurrence], state: AppState):
                 "text": {
                     "type": "mrkdwn",
                     "text": content,
-                }
+                },
+                "expand": True,
             }
         ]
 


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR -->

- [ ] Bugfix
- [x] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

- Add `"expand": True` to the sections for the slack message.
- This avoids rendering the slack messages with a "See More" link
- See [documentation](https://api.slack.com/reference/block-kit/blocks#section)

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [ ] Update documentation
- [ ] Review the [Contributing Guideline](../blob/main/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
