### PR TITLE
SP-000 add path-suffixes to filter better for frontend E2E and vitests failing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ jobs:
           repository: 'Staffbase/test-flaky'
           # optional: name of the branch where it should check, default: main
           branch: 'master'
+          # optional: path suffixes to filter the test files
+          path-suffixes: ".spec.ts,.spec.tsx,.test.ts,.test.tsx"
           # prefix of the test run which should be filtered out
           prefix: 'test-'
           # URL of the Slack incoming webhooks

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
     required: false
     type: string
     default: 'main'
+  path-suffixes:
+    required: false
+    type: string
   prefix:
     required: true
     type: string
@@ -45,6 +48,7 @@ runs:
             --slack-channel "${{ inputs.slack-channel-id }}" \
             --auth-token "${{ inputs.token }}" \
             --prefix "${{ inputs.prefix }}" \
+            --path-suffixes "${{ inputs.path-suffixes }}" \
             ${{ inputs.repository }} \
             ${{ inputs.branch }} \
             > flaky_tests.json

--- a/find_flaky_tests.py
+++ b/find_flaky_tests.py
@@ -31,6 +31,7 @@ class AppState:
     repo: str
     branch: str
     slack_channel: str | None
+    path_suffixes: tuple[str] | None
     prefix: str | None
     since: datetime | None
     until: datetime | None
@@ -54,6 +55,14 @@ def parse_datetime(s):
     else:
         return datetime.strptime(s, '%Y-%m-%d')
 
+# parse_suffixes_tuple is used to parse the suffixes argument from CLI
+# example: ".spec.ts,.spec.tsx,.test.ts,test.tsx" -> ('.spec.ts', '.spec.tsx', '.test.ts', 'test.tsx')
+def parse_suffixes_tuple(s: str | None) -> tuple | None:
+    if s is None:
+        return None
+    else:
+        return tuple(item.strip() for item in s.split(','))
+
 
 def validate_and_split_repo(repo: str) -> (str, str):
     if '/' not in repo:
@@ -69,6 +78,7 @@ def parse_args() -> AppState:
     parser.add_argument('--auth-token', type=str, help='GitHub auth token (required)', required=True)
     parser.add_argument('--slack-channel', type=str,
                         help='Format output for posting in Slack to given channel')
+    parser.add_argument('--path-suffixes', type=str, help='file path suffixes to filter annotations by. Could be tuple ".spec.ts,.spec.tsx,.test.ts,.test.tsx"',)
     parser.add_argument('--prefix', type=str, help='prefix to filter annotations by', required=True)
     parser.add_argument('--since', type=str,
                         help='date to start from, format YYYY-MM-DD defaults to start of day (midnight UTC), '
@@ -91,6 +101,7 @@ def parse_args() -> AppState:
             since=parse_since(args.since),
             until=parse_until(args.until),
             slack_channel=args.slack_channel,
+            path_suffixes=parse_suffixes_tuple(args.path_suffixes),
             prefix=args.prefix
         )
     except Exception as e:
@@ -221,6 +232,9 @@ def list_occurrences(state: AppState, r: Repository) -> List[Occurrence]:
                 if ann.path == '.github':
                     continue
                 # filter out build errors or other issues, which are not flaky tests
+                # filter out annotations that do not match the given suffixes in the file path
+                if state.path_suffixes and not ann.path.endswith(tuple(state.path_suffixes)):
+                    continue
                 if not ann.message.startswith(state.prefix):
                     continue
                 # annotation path contains something like ".../packageA/TestA.xml" or ".../packageB/TestB.kt"

--- a/find_flaky_tests.py
+++ b/find_flaky_tests.py
@@ -31,7 +31,7 @@ class AppState:
     repo: str
     branch: str
     slack_channel: str | None
-    path_suffixes: tuple[str] | None
+    path_suffixes: tuple[str, ...] | None
     prefix: str | None
     since: datetime | None
     until: datetime | None
@@ -57,7 +57,7 @@ def parse_datetime(s):
 
 # parse_suffixes_tuple is used to parse the suffixes argument from CLI
 # example: ".spec.ts,.spec.tsx,.test.ts,test.tsx" -> ('.spec.ts', '.spec.tsx', '.test.ts', 'test.tsx')
-def parse_suffixes_tuple(s: str | None) -> tuple | None:
+def parse_suffixes_tuple(s: str | None) -> tuple[str, ...] | None:
     if s is None:
         return None
     else:


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR -->

- [ ] Bugfix
- [x] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

See [Slack](https://staffbasehq.slack.com/archives/C014EP7NM6G/p1747393136799999?thread_ts=1744738890.033779&cid=C014EP7NM6G)

As we have in the frontend and studio repository different kinds of tests running in the CI, it is not so easy to find a prefix for all of them to list the failing/flaky tests on the default branch. 

Therefore @ikortelainen came up with the idea to use a path suffix.

This is implemented in the PR

### How to test

- code check
- run it locally with `python3 find_flaky_tests.py --auth-token "**********" --prefix '' --path-suffixes '.spec.ts,.spec.tsx, .test.ts, .test.tsx' Staffbase/frontend master`
- or check my results / diffs with some local extra logging
   
````bash
> python3 find_flaky_tests.py --auth-token "**********" --prefix '' --path-suffixes '.spec.ts,.spec.tsx, .test.ts, .test.tsx' Staffbase/frontend master

AppState(auth_token='****', org='Staffbase', repo='frontend', branch='master', slack_channel=None, path_suffixes=('.spec.ts', '.spec.tsx', '.test.ts', 'test.tsx'), prefix='', since=datetime.datetime(2025, 6, 1, 12, 42, 18, 891392), until=datetime.datetime(2025, 6, 8, 12, 42, 18, 891397))

in suffixes  test/e2e-playwright/tests/archived-webdriver-tests/pageobjects/StaticPage.ts skipping
in suffixes  test/e2e-playwright/tests/archived-webdriver-tests/pageobjects/StaticPage.ts skipping
in suffixes  test/e2e-playwright/tests/archived-webdriver-tests/pageobjects/page-widgets/StaticContentWidget.ts skipping
in suffixes  test/e2e-playwright/tests/archived-webdriver-tests/pageobjects/StaticPage.ts skipping
````

diff for two runs with and without the suffixes

````bash
diff find_flaky_tests_frontend.txt find_flaky_tests_frontend_only_prefix.txt
11a12,28
> test/e2e-playwright/tests/archived-webdriver-tests/pageobjects/StaticPage.ts:
>     in 5900ec067af273fcd6a7ce00d1cccb8f50551fb8 on 2025-06-06 14:57:46+00:00, see https://github.com/Staffbase/frontend/actions/runs/15511684638/job/43673445290
..
> test/e2e-playwright/tests/archived-webdriver-tests/pageobjects/page-widgets/StaticContentWidget.ts:
>     in 5900ec067af273fcd6a7ce00d1cccb8f50551fb8 on 2025-06-06 14:57:46+00:00, see https://github.com/Staffbase/frontend/actions/runs/15511684638/job/43673445290
..
> test/e2e-playwright/tests/api/chat-api.ts:
>     in 1bb06ecaefaf9e831db186f5a387fed8131267a7 on 2025-06-06 14:57:46+00:00, see https://github.com/Staffbase/frontend/actions/runs/15490497483/job/43614695140
...
> test/e2e-playwright/tests/archived-webdriver-tests/pageobjects/BaseGeneral.ts:
>     in 1bb06ecaefaf9e831db186f5a387fed8131267a7 on 2025-06-06 14:57:46+00:00, see https://github.com/Staffbase/frontend/actions/runs/15490118050/job/43613499968
...
> test/e2e-playwright/tests/archived-webdriver-tests/pageobjects/Dialog.page.ts:
>     in bfb4c3cdb28679094aca8552e3ed747530755dce on 2025-06-05 10:06:11+00:00, see https://github.com/Staffbase/frontend/actions/runs/15437949376/job/43448679464
````

### TODOs after PR merge

- [ ] add it to the [gha-workflows](https://github.com/Staffbase/gha-workflows?tab=readme-ov-file#find-flaky-tests)
- [ ] use it int the [frontend](https://github.com/Staffbase/frontend/pull/14988) and [studio](https://github.com/Staffbase/experience-studio/pull/5614)


