### PR TITLE
SP-0000 Add flakiness detection and visual timeline

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,6 +4,27 @@ on:
   pull_request:
 
 jobs:
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: Run tests
+        run: python -m pytest test_find_flaky_tests.py -v
+
   dependabot:
     name: Auto Merge (Dependabot)
     uses: Staffbase/gha-workflows/.github/workflows/template_automerge_dependabot.yml@v9.2.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea
 .venv
+__pycache__/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The summary includes two ranked lists (top 10 by default):
 
 Each flaky test shows a compact timeline stripe (oldest → newest):
 
-- 🟢 = mostly passing, 🔴 = mostly failing, 🟡 = mixed results
+- 🟩 = mostly passing, 🟥 = mostly failing, 🟨 = mixed results
 - When there are more than 30 data points, runs are grouped into 30 equal-sized buckets
 - A label like _(100 runs)_ is shown when bucketing is active
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+## Output
+
+The summary includes two ranked lists (top 10 by default):
+
+- **Most failing tests**: ranked by failure count — how often a test path appears in failure annotations within the time window. Shows count and failure rate.
+- **Most flaky tests**: ranked by fail-after-pass rate — how often a test flips from green → red within the same check name. Each flaky test includes a visual timeline stripe showing pass/fail history.
+
+### Timeline visualization
+
+Each flaky test shows a compact timeline stripe (oldest → newest):
+
+- 🟢 = mostly passing, 🔴 = mostly failing, 🟡 = mixed results
+- When there are more than 30 data points, runs are grouped into 30 equal-sized buckets
+- A label like _(100 runs)_ is shown when bucketing is active
+
 ## Release 🔖
 
 To create a new release just use [this page][release-new] and publish the draft release.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Each flaky test shows a compact timeline stripe (oldest → newest):
 - When there are more than 30 data points, runs are grouped into 30 equal-sized buckets
 - A label like _(100 runs)_ is shown when bucketing is active
 
+### Documentation
+
+- [Flakiness Detection — How It Works](docs/flakiness_detection.md)
+- [Slack Output Example](docs/slack_output_example.md)
+
 ## Release 🔖
 
 To create a new release just use [this page][release-new] and publish the draft release.

--- a/docs/flakiness_detection.md
+++ b/docs/flakiness_detection.md
@@ -1,0 +1,88 @@
+# Flakiness Detection: How It Works
+
+## Overview
+
+This script distinguishes between **consistently failing tests** and **truly flaky tests** by analyzing the sequence of pass/fail results over time.
+
+## Method: Fail-After-Pass Detection
+
+The script uses **fail-after-pass transition counting** to measure flakiness.
+
+A "flip" is defined as: a test that **was passing** in a previous run and then **fails again** in a later run — within the same CI check name (e.g. `ci-unit`).
+
+### Algorithm
+
+For each CI check name (e.g. `ci-unit`, `ci-e2e`), the script:
+
+1. Sorts all runs chronologically
+2. Tracks the **last known status** (pass or fail) for every test file
+3. When a test transitions from **pass → fail**, it records a **flip event**
+4. Counts the total number of flips per test
+
+The **flakiness rate** is then:
+
+```
+flakiness_rate = number_of_flips / total_runs
+```
+
+### Example
+
+Given 7 runs of `ci-unit` for two tests:
+
+```
+Run   login.spec.ts   checkout.spec.ts
+─────────────────────────────────────────
+ 1    ❌ fail          ❌ fail
+ 2    ✅ pass          ❌ fail
+ 3    ❌ fail ← flip   ❌ fail
+ 4    ❌ fail          ❌ fail
+ 5    ✅ pass          ❌ fail
+ 6    ❌ fail ← flip   ❌ fail
+ 7    ✅ pass          ❌ fail
+```
+
+| Metric                 | `login.spec.ts` | `checkout.spec.ts` |
+|------------------------|:---------------:|:------------------:|
+| Failures               | 4 / 7           | 7 / 7              |
+| Failure rate           | 57%             | 100%               |
+| Pass → Fail flips      | 2               | 0                  |
+| **Flakiness rate**     | **29%**         | **0%**             |
+
+- `checkout.spec.ts` fails every single time — high failure rate, but **0% flaky** because it never passes, so it can never flip back to red. It's **consistently broken**.
+- `login.spec.ts` alternates between pass and fail — lower failure rate, but **29% flaky** because it keeps flipping. This is the **classic flaky test pattern**.
+
+## What This Detects
+
+✅ Tests that **alternate between green and red** across CI runs — the classic flaky pattern  
+✅ Tests that **fail intermittently** on the same branch with no code changes  
+✅ Differences between "broken" (always red) and "unreliable" (sometimes red)
+
+## What This Does Not Detect
+
+❌ Flakiness **within a single run** (e.g. a test passes on retry inside the same CI job)  
+❌ **Order-dependent** flakiness (test A causes test B to fail)  
+❌ **Environment-dependent** flakiness (works on one runner type, fails on another)  
+❌ **Timing-sensitive** flakiness that only manifests under load
+
+## Output
+
+The script produces two ranked lists:
+
+| List              | Ranked by              | Purpose                                    |
+|-------------------|------------------------|--------------------------------------------|
+| **Most failing**  | Total failure count    | Find tests that are broken the most        |
+| **Most flaky**    | Fail-after-pass rate   | Find tests that flip between green and red  |
+
+Each flaky test includes a **visual timeline stripe** showing its pass/fail history:
+
+```
+29% flaky · 2 flips / 7 runs · login.spec.ts
+🔴🟢🔴🔴🟢🔴🟢
+```
+
+When there are more than 30 data points, runs are **bucketed** into 30 columns. Each column shows the dominant result of its group:
+
+- 🟢 = mostly passing (≤30% failures in bucket)
+- 🔴 = mostly failing (≥70% failures in bucket)
+- 🟡 = mixed results (30–70% failures in bucket)
+

--- a/docs/flakiness_detection.md
+++ b/docs/flakiness_detection.md
@@ -77,12 +77,12 @@ Each flaky test includes a **visual timeline stripe** showing its pass/fail hist
 
 ```
 29% flaky · 2 flips / 7 runs · login.spec.ts
-🔴🟢🔴🔴🟢🔴🟢
+🟥🟩🟥🟥🟩🟥🟩
 ```
 
 When there are more than 30 data points, runs are **bucketed** into 30 columns. Each column shows the dominant result of its group:
 
-- 🟢 = mostly passing (≤30% failures in bucket)
-- 🔴 = mostly failing (≥70% failures in bucket)
-- 🟡 = mixed results (30–70% failures in bucket)
+- 🟩 = mostly passing (≤30% failures in bucket)
+- 🟥 = mostly failing (≥70% failures in bucket)
+- 🟨 = mixed results (30–70% failures in bucket)
 

--- a/docs/slack_output_example.md
+++ b/docs/slack_output_example.md
@@ -24,24 +24,24 @@ This is how the Slack message renders. Use this for your screenshot.
 **🔄 Top 6 flaky tests — green → red flips (limit=10)**
 
   25% flaky (20 flips / 80 runs) `src/modules/auth/login.spec.ts`
-  🟢🟡🟡🟡🟢🟡🟡🟡🟢🟡🟡🟡🔴🟡🟡🟡🟡🟡🟢🟡🟡🟢🟡🟡🟢🟢🟡🟢🟡🟡 _(80 runs)_
+  🟩🟨🟨🟨🟩🟨🟨🟨🟩🟨🟨🟨🟥🟨🟨🟨🟨🟨🟩🟨🟨🟩🟨🟨🟩🟩🟨🟩🟨🟨 _(80 runs)_
 
   24% flaky (19 flips / 80 runs) `src/modules/search/search-results.spec.ts`
-  🔴🟡🟡🔴🟡🟡🟢🟢🟡🟢🟡🟡🟡🟡🔴🟡🟡🟡🟡🔴🟢🟡🟡🟡🟢🟡🟡🟢🟡🟡 _(80 runs)_
+  🟥🟨🟨🟥🟨🟨🟩🟩🟨🟩🟨🟨🟨🟨🟥🟨🟨🟨🟨🟥🟩🟨🟨🟨🟩🟨🟨🟩🟨🟨 _(80 runs)_
 
   19% flaky (15 flips / 80 runs) `src/components/navigation/sidebar.spec.ts`
-  🟡🟡🟢🟡🟢🟡🟡🟡🟡🟡🟡🟡🟡🟢🟢🟢🟡🟡🟡🟢🟡🟢🟡🟢🟡🟢🟢🟢🟢🟡 _(80 runs)_
+  🟨🟨🟩🟨🟩🟨🟨🟨🟨🟨🟨🟨🟨🟩🟩🟩🟨🟨🟨🟩🟨🟩🟨🟩🟨🟩🟩🟩🟩🟨 _(80 runs)_
 
   10% flaky (8 flips / 80 runs) `src/components/dashboard/widget.spec.tsx`
-  🟡🟢🟡🔴🟢🟢🟢🟢🟡🟡🟡🟢🟢🟡🟢🟢🟢🟢🟢🟡🟡🟢🟢🟢🟢🟢🟢🟢🟢🟡 _(80 runs)_
+  🟨🟩🟨🟥🟩🟩🟩🟩🟨🟨🟨🟩🟩🟨🟩🟩🟩🟩🟩🟨🟨🟩🟩🟩🟩🟩🟩🟩🟩🟨 _(80 runs)_
 
   1% flaky (1 flips / 80 runs) `src/modules/settings/profile.spec.tsx`
-  🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟡🟢🟢🟢🟢🟡🟢🟢 _(80 runs)_
+  🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟨🟩🟩🟩🟩🟨🟩🟩 _(80 runs)_
 
   0% flaky (0 flips / 80 runs) `e2e/flows/checkout.spec.ts`
-  🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴 _(80 runs)_
+  🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥 _(80 runs)_
 
-> **Legend:** 🟢 = mostly pass · 🔴 = mostly fail · 🟡 = mixed (oldest → newest)
+> **Legend:** 🟩 = mostly pass · 🟥 = mostly fail · 🟨 = mixed (oldest → newest)
 
 ---
 
@@ -86,7 +86,7 @@ This is how the Slack message renders. Use this for your screenshot.
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": ":arrows_counterclockwise: Top 6 flaky tests \u2014 green \u2192 red flips (limit=10)\n25% flaky (20 flips / 80 runs) `src/modules/auth/login.spec.ts`\n    \ud83d\udfe2\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udd34\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe2\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1 _(80 runs)_\n24% flaky (19 flips / 80 runs) `src/modules/search/search-results.spec.ts`\n    \ud83d\udd34\ud83d\udfe1\ud83d\udfe1\ud83d\udd34\ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe2\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udd34\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udd34\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1 _(80 runs)_\n19% flaky (15 flips / 80 runs) `src/components/navigation/sidebar.spec.ts`\n    \ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe1 _(80 runs)_\n10% flaky (8 flips / 80 runs) `src/components/dashboard/widget.spec.tsx`\n    \ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udd34\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe2\ud83d\udfe1\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe1 _(80 runs)_\n1% flaky (1 flips / 80 runs) `src/modules/settings/profile.spec.tsx`\n    \ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe1\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe1\ud83d\udfe2\ud83d\udfe2 _(80 runs)_\n"
+                "text": ":arrows_counterclockwise: Top 6 flaky tests \u2014 green \u2192 red flips (limit=10)\n25% flaky (20 flips / 80 runs) `src/modules/auth/login.spec.ts`\n    \ud83d\udfe9\ud83d\udfe8\ud83d\udfe8\ud83d\udfe8\ud83d\udfe9\ud83d\udfe8\ud83d\udfe8\ud83d\udfe8\ud83d\udfe9\ud83d\udfe8\ud83d\udfe8\ud83d\udfe8\ud83d\udfe5\ud83d\udfe8\ud83d\udfe8\ud83d\udfe8\ud83d\udfe8\ud83d\udfe8\ud83d\udfe9\ud83d\udfe8\ud83d\udfe8\ud83d\udfe9\ud83d\udfe8\ud83d\udfe8\ud83d\udfe9\ud83d\udfe9\ud83d\udfe8\ud83d\udfe9\ud83d\udfe8\ud83d\udfe8 _(80 runs)_\n24% flaky (19 flips / 80 runs) `src/modules/search/search-results.spec.ts`\n    \ud83d\udfe5\ud83d\udfe8\ud83d\udfe8\ud83d\udfe5\ud83d\udfe8\ud83d\udfe8\ud83d\udfe9\ud83d\udfe9\ud83d\udfe8\ud83d\udfe9\ud83d\udfe8\ud83d\udfe8\ud83d\udfe8\ud83d\udfe8\ud83d\udfe5\ud83d\udfe8\ud83d\udfe8\ud83d\udfe8\ud83d\udfe8\ud83d\udfe5\ud83d\udfe9\ud83d\udfe8\ud83d\udfe8\ud83d\udfe8\ud83d\udfe9\ud83d\udfe8\ud83d\udfe8\ud83d\udfe9\ud83d\udfe8\ud83d\udfe8 _(80 runs)_\n19% flaky (15 flips / 80 runs) `src/components/navigation/sidebar.spec.ts`\n    \ud83d\udfe8\ud83d\udfe8\ud83d\udfe9\ud83d\udfe8\ud83d\udfe9\ud83d\udfe8\ud83d\udfe8\ud83d\udfe8\ud83d\udfe8\ud83d\udfe8\ud83d\udfe8\ud83d\udfe8\ud83d\udfe8\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe8\ud83d\udfe8\ud83d\udfe8\ud83d\udfe9\ud83d\udfe8\ud83d\udfe9\ud83d\udfe8\ud83d\udfe9\ud83d\udfe8\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe8 _(80 runs)_\n10% flaky (8 flips / 80 runs) `src/components/dashboard/widget.spec.tsx`\n    \ud83d\udfe8\ud83d\udfe9\ud83d\udfe8\ud83d\udfe5\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe8\ud83d\udfe8\ud83d\udfe8\ud83d\udfe9\ud83d\udfe9\ud83d\udfe8\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe8\ud83d\udfe8\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe8 _(80 runs)_\n1% flaky (1 flips / 80 runs) `src/modules/settings/profile.spec.tsx`\n    \ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe8\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe9\ud83d\udfe8\ud83d\udfe9\ud83d\udfe9 _(80 runs)_\n"
             },
             "expand": true
         },
@@ -94,7 +94,7 @@ This is how the Slack message renders. Use this for your screenshot.
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": ":arrows_counterclockwise: Top 6 flaky tests \u2014 green \u2192 red flips (limit=10) (cont.)\n0% flaky (0 flips / 80 runs) `e2e/flows/checkout.spec.ts`\n    \ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34 _(80 runs)_\n"
+                "text": ":arrows_counterclockwise: Top 6 flaky tests \u2014 green \u2192 red flips (limit=10) (cont.)\n0% flaky (0 flips / 80 runs) `e2e/flows/checkout.spec.ts`\n    \ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5\ud83d\udfe5 _(80 runs)_\n"
             },
             "expand": true
         }

--- a/docs/slack_output_example.md
+++ b/docs/slack_output_example.md
@@ -1,0 +1,103 @@
+# Slack Message Preview
+
+This is how the Slack message renders. Use this for your screenshot.
+
+---
+
+❄️ **Results for failing / flaky tests in [my-app](https://github.com/Staffbase/my-app) (main):**
+
+**Summary window:** `2025-05-26 00:00:00` — `2025-06-01 23:59:59`
+
+---
+
+**Top 6 failed tests (limit=10)**
+
+  80x (100%) `e2e/flows/checkout.spec.ts` [1](https://github.com/Staffbase/my-app/actions/runs/20250601140000) [2](https://github.com/Staffbase/my-app/actions/runs/20250601120000) [3](https://github.com/Staffbase/my-app/actions/runs/20250601100000) [4](https://github.com/Staffbase/my-app/actions/runs/20250601080000) [5](https://github.com/Staffbase/my-app/actions/runs/20250601060000)
+  36x (45%) `src/modules/search/search-results.spec.ts` [1](https://github.com/Staffbase/my-app/actions/runs/20250601120000) [2](https://github.com/Staffbase/my-app/actions/runs/20250601100000) [3](https://github.com/Staffbase/my-app/actions/runs/20250601080000) [4](https://github.com/Staffbase/my-app/actions/runs/20250601060000) [5](https://github.com/Staffbase/my-app/actions/runs/20250531220000)
+  27x (34%) `src/modules/auth/login.spec.ts` [1](https://github.com/Staffbase/my-app/actions/runs/20250601140000) [2](https://github.com/Staffbase/my-app/actions/runs/20250601100000) [3](https://github.com/Staffbase/my-app/actions/runs/20250601060000) [4](https://github.com/Staffbase/my-app/actions/runs/20250531220000) [5](https://github.com/Staffbase/my-app/actions/runs/20250531020000)
+  21x (26%) `src/components/navigation/sidebar.spec.ts` [1](https://github.com/Staffbase/my-app/actions/runs/20250601120000) [2](https://github.com/Staffbase/my-app/actions/runs/20250531080000) [3](https://github.com/Staffbase/my-app/actions/runs/20250531000000) [4](https://github.com/Staffbase/my-app/actions/runs/20250530120000) [5](https://github.com/Staffbase/my-app/actions/runs/20250530100000)
+  12x (15%) `src/components/dashboard/widget.spec.tsx` [1](https://github.com/Staffbase/my-app/actions/runs/20250601100000) [2](https://github.com/Staffbase/my-app/actions/runs/20250530140000) [3](https://github.com/Staffbase/my-app/actions/runs/20250530060000) [4](https://github.com/Staffbase/my-app/actions/runs/20250528220000) [5](https://github.com/Staffbase/my-app/actions/runs/20250528060000)
+  2x (2%) `src/modules/settings/profile.spec.tsx` [1](https://github.com/Staffbase/my-app/actions/runs/20250601020000) [2](https://github.com/Staffbase/my-app/actions/runs/20250530220000)
+
+---
+
+**🔄 Top 6 flaky tests — green → red flips (limit=10)**
+
+  25% flaky (20 flips / 80 runs) `src/modules/auth/login.spec.ts`
+  🟢🟡🟡🟡🟢🟡🟡🟡🟢🟡🟡🟡🔴🟡🟡🟡🟡🟡🟢🟡🟡🟢🟡🟡🟢🟢🟡🟢🟡🟡 _(80 runs)_
+
+  24% flaky (19 flips / 80 runs) `src/modules/search/search-results.spec.ts`
+  🔴🟡🟡🔴🟡🟡🟢🟢🟡🟢🟡🟡🟡🟡🔴🟡🟡🟡🟡🔴🟢🟡🟡🟡🟢🟡🟡🟢🟡🟡 _(80 runs)_
+
+  19% flaky (15 flips / 80 runs) `src/components/navigation/sidebar.spec.ts`
+  🟡🟡🟢🟡🟢🟡🟡🟡🟡🟡🟡🟡🟡🟢🟢🟢🟡🟡🟡🟢🟡🟢🟡🟢🟡🟢🟢🟢🟢🟡 _(80 runs)_
+
+  10% flaky (8 flips / 80 runs) `src/components/dashboard/widget.spec.tsx`
+  🟡🟢🟡🔴🟢🟢🟢🟢🟡🟡🟡🟢🟢🟡🟢🟢🟢🟢🟢🟡🟡🟢🟢🟢🟢🟢🟢🟢🟢🟡 _(80 runs)_
+
+  1% flaky (1 flips / 80 runs) `src/modules/settings/profile.spec.tsx`
+  🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟡🟢🟢🟢🟢🟡🟢🟢 _(80 runs)_
+
+  0% flaky (0 flips / 80 runs) `e2e/flows/checkout.spec.ts`
+  🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴 _(80 runs)_
+
+> **Legend:** 🟢 = mostly pass · 🔴 = mostly fail · 🟡 = mixed (oldest → newest)
+
+---
+
+### Raw Slack JSON payload
+
+```json
+{
+    "channel": "C12345678",
+    "text": "Flaky Tests Summary",
+    "blocks": [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": ":snowflake: Results for failing / flaky tests in <https://github.com/Staffbase/my-app|my-app> (main):"
+            }
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "Summary window: 2025-05-26 00:00:00 - 2025-06-01 23:59:59"
+            }
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "Top 6 failed tests (limit=10)\n80x (100%) `e2e/flows/checkout.spec.ts` <https://github.com/Staffbase/my-app/actions/runs/20250601140000|1> <https://github.com/Staffbase/my-app/actions/runs/20250601120000|2> <https://github.com/Staffbase/my-app/actions/runs/20250601100000|3> <https://github.com/Staffbase/my-app/actions/runs/20250601080000|4> <https://github.com/Staffbase/my-app/actions/runs/20250601060000|5>\n36x (45%) `src/modules/search/search-results.spec.ts` <https://github.com/Staffbase/my-app/actions/runs/20250601120000|1> <https://github.com/Staffbase/my-app/actions/runs/20250601100000|2> <https://github.com/Staffbase/my-app/actions/runs/20250601080000|3> <https://github.com/Staffbase/my-app/actions/runs/20250601060000|4> <https://github.com/Staffbase/my-app/actions/runs/20250531220000|5>\n27x (34%) `src/modules/auth/login.spec.ts` <https://github.com/Staffbase/my-app/actions/runs/20250601140000|1> <https://github.com/Staffbase/my-app/actions/runs/20250601100000|2> <https://github.com/Staffbase/my-app/actions/runs/20250601060000|3> <https://github.com/Staffbase/my-app/actions/runs/20250531220000|4> <https://github.com/Staffbase/my-app/actions/runs/20250531020000|5>\n21x (26%) `src/components/navigation/sidebar.spec.ts` <https://github.com/Staffbase/my-app/actions/runs/20250601120000|1> <https://github.com/Staffbase/my-app/actions/runs/20250531080000|2> <https://github.com/Staffbase/my-app/actions/runs/20250531000000|3> <https://github.com/Staffbase/my-app/actions/runs/20250530120000|4> <https://github.com/Staffbase/my-app/actions/runs/20250530100000|5>\n12x (15%) `src/components/dashboard/widget.spec.tsx` <https://github.com/Staffbase/my-app/actions/runs/20250601100000|1> <https://github.com/Staffbase/my-app/actions/runs/20250530140000|2> <https://github.com/Staffbase/my-app/actions/runs/20250530060000|3> <https://github.com/Staffbase/my-app/actions/runs/20250528220000|4> <https://github.com/Staffbase/my-app/actions/runs/20250528060000|5>\n"
+            },
+            "expand": true
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "Top 6 failed tests (limit=10) (cont.)\n2x (2%) `src/modules/settings/profile.spec.tsx` <https://github.com/Staffbase/my-app/actions/runs/20250601020000|1> <https://github.com/Staffbase/my-app/actions/runs/20250530220000|2>\n"
+            },
+            "expand": true
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": ":arrows_counterclockwise: Top 6 flaky tests \u2014 green \u2192 red flips (limit=10)\n25% flaky (20 flips / 80 runs) `src/modules/auth/login.spec.ts`\n    \ud83d\udfe2\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udd34\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe2\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1 _(80 runs)_\n24% flaky (19 flips / 80 runs) `src/modules/search/search-results.spec.ts`\n    \ud83d\udd34\ud83d\udfe1\ud83d\udfe1\ud83d\udd34\ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe2\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udd34\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udd34\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1 _(80 runs)_\n19% flaky (15 flips / 80 runs) `src/components/navigation/sidebar.spec.ts`\n    \ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe1 _(80 runs)_\n10% flaky (8 flips / 80 runs) `src/components/dashboard/widget.spec.tsx`\n    \ud83d\udfe1\ud83d\udfe2\ud83d\udfe1\ud83d\udd34\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe2\ud83d\udfe1\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe1\ud83d\udfe1\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe1 _(80 runs)_\n1% flaky (1 flips / 80 runs) `src/modules/settings/profile.spec.tsx`\n    \ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe1\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe2\ud83d\udfe1\ud83d\udfe2\ud83d\udfe2 _(80 runs)_\n"
+            },
+            "expand": true
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": ":arrows_counterclockwise: Top 6 flaky tests \u2014 green \u2192 red flips (limit=10) (cont.)\n0% flaky (0 flips / 80 runs) `e2e/flows/checkout.spec.ts`\n    \ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\udd34 _(80 runs)_\n"
+            },
+            "expand": true
+        }
+    ]
+}
+```

--- a/find_flaky_tests.py
+++ b/find_flaky_tests.py
@@ -9,6 +9,8 @@ from typing import Dict, List
 import json as json_lib
 
 MAX_FILENAME_LENGTH = 60
+TOP_LIMIT = 10
+MAX_TIMELINE_WIDTH = 30  # max columns in timeline stripe
 
 
 @dataclass
@@ -22,6 +24,47 @@ class Occurrence:
     commit: CommitDigest
     check_url: str
     annotation_path: str
+
+
+@dataclass
+class RunInfo:
+    name: str
+    timestamp: datetime
+    check_url: str
+    failed_paths: tuple[str, ...]
+
+
+@dataclass
+class FlipEvent:
+    """Records a single green → red transition for a test."""
+    test_path: str
+    check_name: str
+    passed_at: datetime        # timestamp of the last passing run
+    passed_url: str            # check URL of the last passing run
+    failed_at: datetime        # timestamp of the run that flipped to red
+    failed_url: str            # check URL of the run that flipped to red
+
+
+@dataclass
+class RunResult:
+    """A single run result for a specific test (used for timeline rendering)."""
+    timestamp: datetime
+    check_url: str
+    check_name: str
+    failed: bool
+
+
+@dataclass
+class FileStats:
+    path: str
+    fail_count: int
+    total_runs: int
+    fail_rate: float
+    fail_after_pass: int
+    fail_after_pass_rate: float
+    recent_occurrences: List[Occurrence]
+    flip_events: List[FlipEvent]
+    run_timeline: List[RunResult]
 
 
 @dataclass
@@ -64,7 +107,7 @@ def parse_suffixes_tuple(s: str | None) -> tuple[str, ...] | None:
         return tuple(item.strip() for item in s.split(','))
 
 
-def validate_and_split_repo(repo: str) -> (str, str):
+def validate_and_split_repo(repo: str) -> tuple[str, str]:
     if '/' not in repo:
         raise ValueError(f"Invalid repo format: {repo}")
     org, repo = repo.split('/')
@@ -110,7 +153,10 @@ def parse_args() -> AppState:
         exit(1)
 
 
-def print_for_humans(occurrences: List[Occurrence]):
+def print_for_humans(occurrences: List[Occurrence], stats: List[FileStats]):
+    print_summary_for_humans(stats)
+    print("")
+    print("All matching occurrences:")
     occurrences_by_ann_path: Dict[str, List[Occurrence]] = {}
     for o in occurrences:
         occurrences_by_ann_path.setdefault(o.annotation_path, []).append(o)
@@ -120,6 +166,105 @@ def print_for_humans(occurrences: List[Occurrence]):
             print(f"    in {o.commit.sha} on {o.commit.timestamp}, see {o.check_url}")
 
 
+def print_summary_for_humans(stats: List[FileStats]):
+    most_failing = top_most_failing(stats, TOP_LIMIT)
+    most_flaky = top_most_flaky(stats, TOP_LIMIT)
+
+    print(f"Most failing tests (top {len(most_failing)}, limit={TOP_LIMIT}):")
+    for s in most_failing:
+        print(f"  {s.fail_count}x ({s.fail_rate:.0%}) {s.path}")
+
+    print("")
+    print(f"Most flaky tests (top {len(most_flaky)}, limit={TOP_LIMIT}):")
+    print(f"  Ranked by fail-after-pass rate: how often a test flips from green → red.")
+    print(f"  Timeline: oldest → newest (\033[92m▅\033[0m pass, \033[91m▅\033[0m fail, \033[93m▅\033[0m mixed)"
+          f" — max {MAX_TIMELINE_WIDTH} columns, grouped if more runs")
+    print("")
+    for s in most_flaky:
+        timeline = render_timeline_human(s.run_timeline)
+        print(
+            f"  {s.fail_after_pass_rate:.0%} flaky ({s.fail_after_pass} flips / {s.total_runs} runs) "
+            f"{s.path}"
+        )
+        print(f"    {timeline}")
+
+
+
+def _bucket_timeline(timeline: List[RunResult], max_width: int) -> List[float]:
+    """Group timeline into max_width buckets, each returning a fail ratio (0.0–1.0).
+
+    If timeline fits within max_width, each run is its own bucket.
+    Otherwise, runs are grouped into equal-sized buckets.
+    """
+    n = len(timeline)
+    if n == 0:
+        return []
+    if n <= max_width:
+        return [1.0 if r.failed else 0.0 for r in timeline]
+
+    bucket_size = n / max_width
+    buckets: List[float] = []
+    for i in range(max_width):
+        start = int(i * bucket_size)
+        end = int((i + 1) * bucket_size)
+        if end <= start:
+            end = start + 1
+        chunk = timeline[start:end]
+        fail_count = sum(1 for r in chunk if r.failed)
+        buckets.append(fail_count / len(chunk))
+    return buckets
+
+
+def render_timeline_human(timeline: List[RunResult]) -> str:
+    """Render a compact pass/fail stripe using ANSI-colored block characters.
+
+    If timeline has more entries than MAX_TIMELINE_WIDTH, runs are bucketed.
+    Each column shows: green (mostly pass), red (mostly fail), yellow (mixed).
+    """
+    buckets = _bucket_timeline(timeline, MAX_TIMELINE_WIDTH)
+    if not buckets:
+        return ""
+    RED = "\033[91m"
+    GREEN = "\033[92m"
+    YELLOW = "\033[93m"
+    RESET = "\033[0m"
+    chars = []
+    for ratio in buckets:
+        if ratio >= 0.7:
+            chars.append(f"{RED}▅{RESET}")
+        elif ratio <= 0.3:
+            chars.append(f"{GREEN}▅{RESET}")
+        else:
+            chars.append(f"{YELLOW}▅{RESET}")
+    label = ""
+    if len(timeline) > MAX_TIMELINE_WIDTH:
+        label = f" ({len(timeline)} runs)"
+    return "".join(chars) + label
+
+
+def render_timeline_slack(timeline: List[RunResult]) -> str:
+    """Render a compact pass/fail stripe for Slack using small emoji.
+
+    If timeline has more entries than MAX_TIMELINE_WIDTH, runs are bucketed.
+    Each column shows: 🟢 (mostly pass), 🔴 (mostly fail), 🟡 (mixed).
+    """
+    buckets = _bucket_timeline(timeline, MAX_TIMELINE_WIDTH)
+    if not buckets:
+        return ""
+    chars = []
+    for ratio in buckets:
+        if ratio >= 0.7:
+            chars.append("🔴")
+        elif ratio <= 0.3:
+            chars.append("🟢")
+        else:
+            chars.append("🟡")
+    label = ""
+    if len(timeline) > MAX_TIMELINE_WIDTH:
+        label = f" _({len(timeline)} runs)_"
+    return "".join(chars) + label
+
+
 def truncate_left(s: str, n: int) -> str:
     if len(s) <= n:
         return s
@@ -127,48 +272,25 @@ def truncate_left(s: str, n: int) -> str:
 
 
 def render_msg_header(state: AppState) -> str:
-    return ':snowflake: Search results for flaky tests in ' + \
+    return ':snowflake: Results for failing / flaky tests in ' + \
         f'<https://github.com/{state.org}/{state.repo}|{state.repo}> ({state.branch}):'
 
 
-def print_for_slack(occurrences: List[Occurrence], state: AppState):
-    occurrences_by_ann_path: Dict[str, List[Occurrence]] = {}
-    for o in occurrences:
-        occurrences_by_ann_path.setdefault(o.annotation_path, []).append(o)
-    items = [i for i in occurrences_by_ann_path.items()]
-    items.sort(key=lambda i: len(i[1]), reverse=True)  # sort by number of occurrences, highest first
-
-    limit = 12
-    items = items[:limit]
-
-    # Chunk results so that individual message blocks do not exceed the 3000 character limit from Slack API
-    chunk_size=5
-    chunks = [items[i:i+chunk_size] for i in range(0, len(items), chunk_size)]
+def print_for_slack(occurrences: List[Occurrence], stats: List[FileStats], state: AppState):
+    most_failing = top_most_failing(stats, TOP_LIMIT)
+    most_flaky = top_most_flaky(stats, TOP_LIMIT)
 
     content_blocks = []
-
-    for chunk in chunks:
-        content = ""
-        for ann_path, occrs in chunk:
-            nice_path = truncate_left(ann_path, MAX_FILENAME_LENGTH)
-            count = len(occrs)
-            content += f"{count}x `{nice_path}` "
-            occrs.sort(key=lambda o: o.commit.timestamp, reverse=True)
-            recent_occrs = occrs[:5]
-            content += " ".join([f"<{occr.check_url}|{i+1}> " for i, occr in enumerate(recent_occrs)])
-            content += '\n'
-
-        content_blocks += [
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": content,
-                },
-                "expand": True,
-            }
-        ]
-
+    content_blocks += render_slack_list(
+        f"Top {len(most_failing)} failed tests (limit={TOP_LIMIT})",
+        most_failing,
+        format_failing_item,
+    )
+    content_blocks += render_slack_list(
+        f":arrows_counterclockwise: Top {len(most_flaky)} flaky tests — green → red flips (limit={TOP_LIMIT})",
+        most_flaky,
+        format_flaky_item,
+    )
 
     data = {
         "channel": state.slack_channel,
@@ -185,15 +307,68 @@ def print_for_slack(occurrences: List[Occurrence], state: AppState):
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"Top {len(items)} failed runs (limit={limit})",
+                    "text": f"Summary window: {state.since} - {state.until}",
                 }
-            }
+            },
         ] + content_blocks
     }
 
     json = json_lib.dumps(data, indent=4)
 
     print(json)
+
+
+def render_slack_list(title: str, items: List[FileStats], formatter) -> List[dict]:
+    if not items:
+        return [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"{title}\n_No results_",
+                },
+            }
+        ]
+
+    content_blocks = []
+    chunk_size = 5
+    chunks = [items[i:i + chunk_size] for i in range(0, len(items), chunk_size)]
+
+    for idx, chunk in enumerate(chunks):
+        content = ""
+        for s in chunk:
+            content += formatter(s)
+            content += "\n"
+
+        header = title if idx == 0 else f"{title} (cont.)"
+        content_blocks.append(
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"{header}\n{content}",
+                },
+                "expand": True,
+            }
+        )
+
+    return content_blocks
+
+
+def format_failing_item(s: FileStats) -> str:
+    nice_path = truncate_left(s.path, MAX_FILENAME_LENGTH)
+    recent = sorted(s.recent_occurrences, key=lambda o: o.commit.timestamp, reverse=True)[:5]
+    links = " ".join([f"<{o.check_url}|{i + 1}>" for i, o in enumerate(recent)])
+    return f"{s.fail_count}x ({s.fail_rate:.0%}) `{nice_path}` {links}".rstrip()
+
+
+def format_flaky_item(s: FileStats) -> str:
+    nice_path = truncate_left(s.path, MAX_FILENAME_LENGTH)
+    timeline = render_timeline_slack(s.run_timeline)
+    return (
+        f"{s.fail_after_pass_rate:.0%} flaky ({s.fail_after_pass} flips / {s.total_runs} runs) "
+        f"`{nice_path}`\n    {timeline}"
+    )
 
 
 def access_repo(state: AppState) -> Repository:
@@ -203,8 +378,9 @@ def access_repo(state: AppState) -> Repository:
     return o.get_repo(state.repo)
 
 
-def list_occurrences(state: AppState, r: Repository) -> List[Occurrence]:
+def list_occurrences(state: AppState, r: Repository) -> tuple[List[Occurrence], List[RunInfo]]:
     occurrences: List[Occurrence] = []
+    runs: List[RunInfo] = []
     commits_pl = r.get_commits(sha=state.branch, since=state.since, until=state.until)
     for c in commits_pl:
         # ignore commit check suites that are not for the current branch (e.g. != master)
@@ -222,39 +398,162 @@ def list_occurrences(state: AppState, r: Repository) -> List[Occurrence]:
         for cr in check_runs_pl:
             if cr.status != "completed":  # still running
                 continue
-            if cr.conclusion != "failure":  # we want only failures
-                continue
-            if cr.output.annotations_count == 0:  # small optimization, don't fetch what's not there
-                continue
-            annotations_pl = cr.get_annotations()
-            for ann in annotations_pl:
-                # filter out github meta annotation path, which is useless for our summary
-                if ann.path == '.github':
-                    continue
-                # filter out build errors or other issues, which are not flaky tests
-                # filter out annotations that do not match the given suffixes in the file path
-                if state.path_suffixes and not ann.path.endswith(tuple(state.path_suffixes)):
-                    continue
-                if not ann.message.startswith(state.prefix):
-                    continue
-                # annotation path contains something like ".../packageA/TestA.xml" or ".../packageB/TestB.kt"
-                occr = Occurrence(digest, cr.html_url, ann.path)
+
+            run_ts = cr.completed_at or c_ts
+            failed_paths: set[str] = set()
+
+            if cr.conclusion == "failure" and cr.output.annotations_count:
+                annotations_pl = cr.get_annotations()
+                for ann in annotations_pl:
+                    # filter out GitHub meta annotation path, which is useless for our summary
+                    if ann.path == '.github':
+                        continue
+                    # filter out build errors or other issues, which are not flaky tests
+                    # filter out annotations that do not match the given suffixes in the file path
+                    if state.path_suffixes and not ann.path.endswith(tuple(state.path_suffixes)):
+                        continue
+                    if not ann.message.startswith(state.prefix):
+                        continue
+                    # annotation path contains something like ".../packageA/TestA.xml" or ".../packageB/TestB.kt"
+                    failed_paths.add(ann.path)
+
+            runs.append(
+                RunInfo(
+                    name=cr.name,
+                    timestamp=run_ts,
+                    check_url=cr.html_url,
+                    failed_paths=tuple(sorted(failed_paths)),
+                )
+            )
+
+            for path in failed_paths:
+                occr = Occurrence(digest, cr.html_url, path)
 
                 # skip duplicates, if one file has multiple annotations
                 if len(occurrences) > 0 and occurrences[-1] == occr:
                     continue
                 occurrences.append(occr)
-    return occurrences
+    return occurrences, runs
+
+
+def compute_test_stats(occurrences: List[Occurrence], runs: List[RunInfo]) -> List[FileStats]:
+    occurrences_by_path: Dict[str, List[Occurrence]] = {}
+    for o in occurrences:
+        occurrences_by_path.setdefault(o.annotation_path, []).append(o)
+
+    total_runs_by_check: Dict[str, int] = {}
+    runs_by_check: Dict[str, List[RunInfo]] = {}
+    fail_counts: Dict[str, int] = {}
+    test_to_checks: Dict[str, set[str]] = {}
+
+    for run in runs:
+        total_runs_by_check[run.name] = total_runs_by_check.get(run.name, 0) + 1
+        runs_by_check.setdefault(run.name, []).append(run)
+        for path in run.failed_paths:
+            fail_counts[path] = fail_counts.get(path, 0) + 1
+            test_to_checks.setdefault(path, set()).add(run.name)
+
+    fail_after_pass: Dict[str, int] = {}
+    flip_events: Dict[str, List[FlipEvent]] = {}
+    known_tests_per_check: Dict[str, set[str]] = {}
+    for check_name, check_runs in runs_by_check.items():
+        check_runs.sort(key=lambda r: r.timestamp)
+        known_tests: set[str] = set()
+        last_status: Dict[str, bool] = {}
+        last_pass_run: Dict[str, RunInfo] = {}
+        for run in check_runs:
+            failed = set(run.failed_paths)
+            for test in known_tests - failed:
+                last_status[test] = False
+                last_pass_run[test] = run
+            for test in failed:
+                if test in last_status and last_status[test] is False:
+                    fail_after_pass[test] = fail_after_pass.get(test, 0) + 1
+                    prev = last_pass_run[test]
+                    flip_events.setdefault(test, []).append(
+                        FlipEvent(
+                            test_path=test,
+                            check_name=check_name,
+                            passed_at=prev.timestamp,
+                            passed_url=prev.check_url,
+                            failed_at=run.timestamp,
+                            failed_url=run.check_url,
+                        )
+                    )
+                last_status[test] = True
+                known_tests.add(test)
+        known_tests_per_check[check_name] = known_tests
+
+    # Build per-test timeline: for each test, collect all runs from relevant checks
+    # sorted by time, showing whether the test failed in that run or not.
+    test_timelines: Dict[str, List[RunResult]] = {}
+    for check_name, check_runs in runs_by_check.items():
+        # check_runs already sorted by timestamp from the loop above
+        for run in check_runs:
+            failed_set = set(run.failed_paths)
+            # Only include runs for checks that are relevant to at least one known test
+            for test in known_tests_per_check.get(check_name, set()):
+                test_timelines.setdefault(test, []).append(
+                    RunResult(
+                        timestamp=run.timestamp,
+                        check_url=run.check_url,
+                        check_name=check_name,
+                        failed=test in failed_set,
+                    )
+                )
+    # Sort each timeline by timestamp
+    for tl in test_timelines.values():
+        tl.sort(key=lambda r: r.timestamp)
+
+    stats: List[FileStats] = []
+    for path, fail_count in fail_counts.items():
+        checks = test_to_checks.get(path, set())
+        total_runs = sum(total_runs_by_check.get(name, 0) for name in checks)
+        if total_runs == 0:
+            continue
+        fap = fail_after_pass.get(path, 0)
+        stats.append(
+            FileStats(
+                path=path,
+                fail_count=fail_count,
+                total_runs=total_runs,
+                fail_rate=fail_count / total_runs,
+                fail_after_pass=fap,
+                fail_after_pass_rate=fap / total_runs,
+                recent_occurrences=occurrences_by_path.get(path, []),
+                flip_events=sorted(flip_events.get(path, []), key=lambda e: e.failed_at),
+                run_timeline=test_timelines.get(path, []),
+            )
+        )
+
+    return stats
+
+
+def top_most_failing(stats: List[FileStats], limit: int) -> List[FileStats]:
+    return sorted(
+        stats,
+        key=lambda s: (s.fail_count, s.fail_rate),
+        reverse=True,
+    )[:limit]
+
+
+def top_most_flaky(stats: List[FileStats], limit: int) -> List[FileStats]:
+    return sorted(
+        stats,
+        key=lambda s: (s.fail_after_pass_rate, s.fail_after_pass, s.fail_rate),
+        reverse=True,
+    )[:limit]
 
 
 def main():
     state: AppState = parse_args()
     r = access_repo(state)
-    occurrences = list_occurrences(state, r)
+    occurrences, runs = list_occurrences(state, r)
+    stats = compute_test_stats(occurrences, runs)
     if state.slack_channel:
-        print_for_slack(occurrences, state)
+        print_for_slack(occurrences, stats, state)
     else:
-        print_for_humans(occurrences)
+        print_for_humans(occurrences, stats)
 
 
 if __name__ == '__main__':

--- a/find_flaky_tests.py
+++ b/find_flaky_tests.py
@@ -356,18 +356,28 @@ def render_slack_list(title: str, items: List[FileStats], formatter) -> List[dic
 
 
 def format_failing_item(s: FileStats) -> str:
+    """Format a single failing test for Slack output.
+
+    Example: *5x* (100%) `e2e/checkout.spec.ts`  1 2 3 4 5
+    """
     nice_path = truncate_left(s.path, MAX_FILENAME_LENGTH)
     recent = sorted(s.recent_occurrences, key=lambda o: o.commit.timestamp, reverse=True)[:5]
     links = " ".join([f"<{o.check_url}|{i + 1}>" for i, o in enumerate(recent)])
-    return f"{s.fail_count}x ({s.fail_rate:.0%}) `{nice_path}` {links}".rstrip()
+    return f"*{s.fail_count}x* ({s.fail_rate:.0%}) `{nice_path}`  {links}".rstrip()
 
 
 def format_flaky_item(s: FileStats) -> str:
+    """Format a single flaky test for Slack output.
+
+    Example:
+    *29%* flaky · 3 flips / 10 runs · `src/auth/login.spec.ts`
+    🔴🟢🔴🔴🟢🔴🟢🟢🔴🟢
+    """
     nice_path = truncate_left(s.path, MAX_FILENAME_LENGTH)
     timeline = render_timeline_slack(s.run_timeline)
     return (
-        f"{s.fail_after_pass_rate:.0%} flaky ({s.fail_after_pass} flips / {s.total_runs} runs) "
-        f"`{nice_path}`\n    {timeline}"
+        f"*{s.fail_after_pass_rate:.0%}* flaky · {s.fail_after_pass} flips / {s.total_runs} runs · "
+        f"`{nice_path}`\n{timeline}"
     )
 
 

--- a/find_flaky_tests.py
+++ b/find_flaky_tests.py
@@ -243,10 +243,13 @@ def render_timeline_human(timeline: List[RunResult]) -> str:
 
 
 def render_timeline_slack(timeline: List[RunResult]) -> str:
-    """Render a compact pass/fail stripe for Slack using small emoji.
+    """Render a compact pass/fail stripe for Slack using square emoji.
+
+    Square emoji (🟩🟥🟨) tile together without gaps, producing a denser
+    color bar than circle emoji.
 
     If timeline has more entries than MAX_TIMELINE_WIDTH, runs are bucketed.
-    Each column shows: 🟢 (mostly pass), 🔴 (mostly fail), 🟡 (mixed).
+    Each column shows: 🟩 (mostly pass), 🟥 (mostly fail), 🟨 (mixed).
     """
     buckets = _bucket_timeline(timeline, MAX_TIMELINE_WIDTH)
     if not buckets:
@@ -254,11 +257,11 @@ def render_timeline_slack(timeline: List[RunResult]) -> str:
     chars = []
     for ratio in buckets:
         if ratio >= 0.7:
-            chars.append("🔴")
+            chars.append("🟥")
         elif ratio <= 0.3:
-            chars.append("🟢")
+            chars.append("🟩")
         else:
-            chars.append("🟡")
+            chars.append("🟨")
     label = ""
     if len(timeline) > MAX_TIMELINE_WIDTH:
         label = f" _({len(timeline)} runs)_"
@@ -371,7 +374,7 @@ def format_flaky_item(s: FileStats) -> str:
 
     Example:
     *29%* flaky · 3 flips / 10 runs · `src/auth/login.spec.ts`
-    🔴🟢🔴🔴🟢🔴🟢🟢🔴🟢
+    🟥🟩🟥🟥🟩🟥🟩🟩🟥🟩
     """
     nice_path = truncate_left(s.path, MAX_FILENAME_LENGTH)
     timeline = render_timeline_slack(s.run_timeline)

--- a/test_find_flaky_tests.py
+++ b/test_find_flaky_tests.py
@@ -139,9 +139,9 @@ def test_format_flaky_item():
     assert "2 flips / 5 runs" in result
     assert "·" in result  # dot separators
     assert "TestB.spec.ts" in result
-    # Should contain compact Slack timeline emoji
-    assert "🔴" in result
-    assert "🟢" in result
+    # Should contain compact Slack timeline square emoji
+    assert "🟥" in result
+    assert "🟩" in result
 
 
 def test_print_summary_for_humans(capsys):
@@ -180,7 +180,7 @@ def test_render_timeline_slack():
         RunResult(datetime(2025, 6, 1, 3), "u3", "ci", True),
     ]
     result = render_timeline_slack(tl)
-    assert result == "🔴🟢🔴"
+    assert result == "🟥🟩🟥"
 
 
 def test_render_timeline_empty():
@@ -336,8 +336,8 @@ def test_render_timeline_slack_bucketed():
         for i in range(60)
     ]
     result = render_timeline_slack(tl)
-    # Count emoji characters (🔴, 🟢, 🟡)
-    emoji_count = sum(1 for c in result if c in "🔴🟢🟡")
+    # Count emoji characters (🟥, 🟩, 🟨)
+    emoji_count = sum(1 for c in result if c in "🟥🟩🟨")
     assert emoji_count == MAX_TIMELINE_WIDTH
     # Should show total run count
     assert "(60 runs)" in result
@@ -351,11 +351,11 @@ def test_render_timeline_slack_no_label_when_small():
     ]
     result = render_timeline_slack(tl)
     assert "runs)" not in result
-    assert result == "🟢🟢🟢🟢🟢"
+    assert result == "🟩🟩🟩🟩🟩"
 
 
 def test_render_timeline_slack_yellow_mixed():
-    """Buckets with ~50/50 pass/fail should show yellow 🟡."""
+    """Buckets with ~50/50 pass/fail should show yellow 🟨."""
     # 60 runs alternating fail/pass → each 2-run bucket has 1 fail + 1 pass = 0.5 ratio → yellow
     base = datetime(2025, 6, 1)
     tl = [
@@ -363,7 +363,7 @@ def test_render_timeline_slack_yellow_mixed():
         for i in range(60)
     ]
     result = render_timeline_slack(tl)
-    assert "🟡" in result
+    assert "🟨" in result
 
 
 if __name__ == "__main__":

--- a/test_find_flaky_tests.py
+++ b/test_find_flaky_tests.py
@@ -125,7 +125,7 @@ def test_format_failing_item():
     stats = compute_test_stats(occurrences, runs)
     by_path = {s.path: s for s in stats}
     result = format_failing_item(by_path["TestA.spec.ts"])
-    assert "5x" in result
+    assert "*5x*" in result
     assert "100%" in result
     assert "TestA.spec.ts" in result
 
@@ -135,8 +135,9 @@ def test_format_flaky_item():
     stats = compute_test_stats(occurrences, runs)
     by_path = {s.path: s for s in stats}
     result = format_flaky_item(by_path["TestB.spec.ts"])
-    assert "40%" in result
+    assert "*40%*" in result
     assert "2 flips / 5 runs" in result
+    assert "·" in result  # dot separators
     assert "TestB.spec.ts" in result
     # Should contain compact Slack timeline emoji
     assert "🔴" in result

--- a/test_find_flaky_tests.py
+++ b/test_find_flaky_tests.py
@@ -1,0 +1,386 @@
+"""Unit tests for compute_test_stats and ranking helpers."""
+from datetime import datetime, timedelta
+from find_flaky_tests import (
+    CommitDigest,
+    FlipEvent,
+    Occurrence,
+    RunInfo,
+    RunResult,
+    FileStats,
+    MAX_TIMELINE_WIDTH,
+    _bucket_timeline,
+    compute_test_stats,
+    top_most_failing,
+    top_most_flaky,
+    format_failing_item,
+    format_flaky_item,
+    print_summary_for_humans,
+    render_timeline_human,
+    render_timeline_slack,
+)
+
+
+def _digest(sha: str, ts: str = "2025-06-01T10:00:00Z") -> CommitDigest:
+    return CommitDigest(sha=sha, timestamp=datetime.fromisoformat(ts.replace("Z", "+00:00")))
+
+
+def _occ(sha: str, path: str, url: str = "https://example.com/check/1") -> Occurrence:
+    return Occurrence(commit=_digest(sha), check_url=url, annotation_path=path)
+
+
+def _run(name: str, ts: str, failed: tuple[str, ...] = (), url: str = "https://example.com/check/1") -> RunInfo:
+    return RunInfo(
+        name=name,
+        timestamp=datetime.fromisoformat(ts.replace("Z", "+00:00")),
+        check_url=url,
+        failed_paths=failed,
+    )
+
+
+# ── Scenario: a consistently failing test vs a flaky test ──────────────────────
+# TestA fails every run   → high fail count, 0 fail-after-pass (never passes)
+# TestB fails, passes, fails → lower fail count, but has fail-after-pass transitions
+def make_scenario():
+    runs = [
+        # check "ci" run 1: TestA fails, TestB fails
+        _run("ci", "2025-06-01T01:00:00Z", ("TestA.spec.ts", "TestB.spec.ts")),
+        # check "ci" run 2: TestA fails, TestB passes
+        _run("ci", "2025-06-01T02:00:00Z", ("TestA.spec.ts",)),
+        # check "ci" run 3: TestA fails, TestB fails again (fail-after-pass!)
+        _run("ci", "2025-06-01T03:00:00Z", ("TestA.spec.ts", "TestB.spec.ts")),
+        # check "ci" run 4: TestA fails, TestB passes
+        _run("ci", "2025-06-01T04:00:00Z", ("TestA.spec.ts",)),
+        # check "ci" run 5: TestA fails, TestB fails again (another fail-after-pass)
+        _run("ci", "2025-06-01T05:00:00Z", ("TestA.spec.ts", "TestB.spec.ts")),
+    ]
+    occurrences = []
+    for i, r in enumerate(runs):
+        for p in r.failed_paths:
+            occurrences.append(_occ(f"sha{i}", p, r.check_url))
+    return occurrences, runs
+
+
+def test_compute_test_stats_counts():
+    occurrences, runs = make_scenario()
+    stats = compute_test_stats(occurrences, runs)
+
+    by_path = {s.path: s for s in stats}
+    assert "TestA.spec.ts" in by_path
+    assert "TestB.spec.ts" in by_path
+
+    a = by_path["TestA.spec.ts"]
+    b = by_path["TestB.spec.ts"]
+
+    # TestA fails in all 5 runs
+    assert a.fail_count == 5
+    assert a.total_runs == 5
+    assert a.fail_rate == 1.0
+    # TestA never passes then fails again – it fails from the start and keeps failing
+    assert a.fail_after_pass == 0
+
+    # TestB fails in 3 of 5 runs
+    assert b.fail_count == 3
+    assert b.total_runs == 5
+    assert b.fail_rate == 3 / 5
+    # TestB has 2 fail-after-pass transitions (run3 and run5)
+    assert b.fail_after_pass == 2
+    assert b.fail_after_pass_rate == 2 / 5
+
+    # TestA has no flips → no flip events
+    assert a.flip_events == []
+
+    # TestB has 2 flip events with correct timestamps
+    assert len(b.flip_events) == 2
+    # First flip: passed at run2 (02:00), failed at run3 (03:00)
+    assert b.flip_events[0].check_name == "ci"
+    assert b.flip_events[0].passed_at.hour == 2
+    assert b.flip_events[0].failed_at.hour == 3
+    # Second flip: passed at run4 (04:00), failed at run5 (05:00)
+    assert b.flip_events[1].passed_at.hour == 4
+    assert b.flip_events[1].failed_at.hour == 5
+
+
+def test_top_most_failing_ranks_by_count():
+    occurrences, runs = make_scenario()
+    stats = compute_test_stats(occurrences, runs)
+    top = top_most_failing(stats, 12)
+
+    # TestA (5 failures) should be ranked above TestB (3 failures)
+    assert top[0].path == "TestA.spec.ts"
+    assert top[1].path == "TestB.spec.ts"
+
+
+def test_top_most_flaky_ranks_by_fail_after_pass():
+    occurrences, runs = make_scenario()
+    stats = compute_test_stats(occurrences, runs)
+    top = top_most_flaky(stats, 12)
+
+    # TestB (40% fail-after-pass) should be ranked above TestA (0% fail-after-pass)
+    assert top[0].path == "TestB.spec.ts"
+    assert top[1].path == "TestA.spec.ts"
+
+
+def test_format_failing_item():
+    occurrences, runs = make_scenario()
+    stats = compute_test_stats(occurrences, runs)
+    by_path = {s.path: s for s in stats}
+    result = format_failing_item(by_path["TestA.spec.ts"])
+    assert "5x" in result
+    assert "100%" in result
+    assert "TestA.spec.ts" in result
+
+
+def test_format_flaky_item():
+    occurrences, runs = make_scenario()
+    stats = compute_test_stats(occurrences, runs)
+    by_path = {s.path: s for s in stats}
+    result = format_flaky_item(by_path["TestB.spec.ts"])
+    assert "40%" in result
+    assert "2 flips / 5 runs" in result
+    assert "TestB.spec.ts" in result
+    # Should contain compact Slack timeline emoji
+    assert "🔴" in result
+    assert "🟢" in result
+
+
+def test_print_summary_for_humans(capsys):
+    occurrences, runs = make_scenario()
+    stats = compute_test_stats(occurrences, runs)
+    print_summary_for_humans(stats)
+    captured = capsys.readouterr().out
+    assert "Most failing tests" in captured
+    assert "Most flaky tests" in captured
+    assert "green → red" in captured
+    assert "TestA.spec.ts" in captured
+    assert "TestB.spec.ts" in captured
+    # Timeline stripes should use ▅ block characters
+    assert "▅" in captured
+
+
+def test_render_timeline_human():
+    tl = [
+        RunResult(datetime(2025, 6, 1, 1), "u1", "ci", True),
+        RunResult(datetime(2025, 6, 1, 2), "u2", "ci", False),
+        RunResult(datetime(2025, 6, 1, 3), "u3", "ci", True),
+        RunResult(datetime(2025, 6, 1, 4), "u4", "ci", False),
+        RunResult(datetime(2025, 6, 1, 5), "u5", "ci", False),
+    ]
+    result = render_timeline_human(tl)
+    # Should contain 5 ▅ block characters with ANSI color codes
+    assert result.count("▅") == 5
+    assert "\033[91m" in result  # red ANSI
+    assert "\033[92m" in result  # green ANSI
+
+
+def test_render_timeline_slack():
+    tl = [
+        RunResult(datetime(2025, 6, 1, 1), "u1", "ci", True),
+        RunResult(datetime(2025, 6, 1, 2), "u2", "ci", False),
+        RunResult(datetime(2025, 6, 1, 3), "u3", "ci", True),
+    ]
+    result = render_timeline_slack(tl)
+    assert result == "🔴🟢🔴"
+
+
+def test_render_timeline_empty():
+    assert render_timeline_human([]) == ""
+    assert render_timeline_slack([]) == ""
+
+
+def test_run_timeline_in_stats():
+    """Verify that run_timeline is populated correctly in FileStats."""
+    occurrences, runs = make_scenario()
+    stats = compute_test_stats(occurrences, runs)
+    by_path = {s.path: s for s in stats}
+
+    # TestA fails every run → all red
+    a_tl = by_path["TestA.spec.ts"].run_timeline
+    assert len(a_tl) == 5
+    assert all(r.failed for r in a_tl)
+    a_rendered = render_timeline_human(a_tl)
+    assert a_rendered.count("▅") == 5
+    assert "\033[92m" not in a_rendered  # no green
+
+    # TestB: fail, pass, fail, pass, fail → alternating
+    b_tl = by_path["TestB.spec.ts"].run_timeline
+    assert len(b_tl) == 5
+    expected = [True, False, True, False, True]
+    assert [r.failed for r in b_tl] == expected
+    b_rendered = render_timeline_human(b_tl)
+    assert b_rendered.count("▅") == 5
+    assert "\033[91m" in b_rendered  # has red
+    assert "\033[92m" in b_rendered  # has green
+
+
+def test_empty_runs():
+    stats = compute_test_stats([], [])
+    assert stats == []
+    assert top_most_failing(stats, 12) == []
+    assert top_most_flaky(stats, 12) == []
+
+
+def test_multiple_check_names():
+    """Tests that run across different check names are handled correctly."""
+    runs = [
+        _run("lint", "2025-06-01T01:00:00Z", ("TestC.spec.ts",)),
+        _run("lint", "2025-06-01T02:00:00Z", ()),  # passes
+        _run("lint", "2025-06-01T03:00:00Z", ("TestC.spec.ts",)),  # fail-after-pass
+        _run("unit", "2025-06-01T01:00:00Z", ("TestC.spec.ts",)),
+        _run("unit", "2025-06-01T02:00:00Z", ()),  # passes
+        _run("unit", "2025-06-01T03:00:00Z", ()),  # stays passing
+    ]
+    occurrences = []
+    for i, r in enumerate(runs):
+        for p in r.failed_paths:
+            occurrences.append(_occ(f"sha{i}", p, r.check_url))
+
+    stats = compute_test_stats(occurrences, runs)
+    assert len(stats) == 1
+    c = stats[0]
+    assert c.path == "TestC.spec.ts"
+    # fails in 3 runs total (lint:2 + unit:1), total_runs = lint:3 + unit:3 = 6
+    assert c.fail_count == 3
+    assert c.total_runs == 6
+    # fail-after-pass: 1 in lint, 0 in unit = 1
+    assert c.fail_after_pass == 1
+    assert c.fail_after_pass_rate == 1 / 6
+    # flip event comes from the "lint" check
+    assert len(c.flip_events) == 1
+    assert c.flip_events[0].check_name == "lint"
+    assert c.flip_events[0].passed_at.hour == 2
+    assert c.flip_events[0].failed_at.hour == 3
+
+
+def test_flip_events_record_correct_urls():
+    """Flip events should record the URLs of the passing and failing runs."""
+    runs = [
+        _run("ci", "2025-06-01T01:00:00Z", ("Flaky.spec.ts",), url="https://example.com/run/1"),
+        _run("ci", "2025-06-01T02:00:00Z", (),                  url="https://example.com/run/2"),  # pass
+        _run("ci", "2025-06-01T03:00:00Z", ("Flaky.spec.ts",),  url="https://example.com/run/3"),  # flip!
+    ]
+    occurrences = []
+    for i, r in enumerate(runs):
+        for p in r.failed_paths:
+            occurrences.append(_occ(f"sha{i}", p, r.check_url))
+
+    stats = compute_test_stats(occurrences, runs)
+    assert len(stats) == 1
+    s = stats[0]
+    assert len(s.flip_events) == 1
+    flip = s.flip_events[0]
+    assert flip.test_path == "Flaky.spec.ts"
+    assert flip.check_name == "ci"
+    assert flip.passed_url == "https://example.com/run/2"
+    assert flip.failed_url == "https://example.com/run/3"
+
+
+def test_bucket_timeline_small():
+    """When runs fit within max_width, each run is its own bucket."""
+    tl = [
+        RunResult(datetime(2025, 6, 1, i), "", "ci", i % 2 == 0)
+        for i in range(5)
+    ]
+    buckets = _bucket_timeline(tl, 30)
+    assert len(buckets) == 5
+    assert buckets == [1.0, 0.0, 1.0, 0.0, 1.0]
+
+
+def test_bucket_timeline_large():
+    """When runs exceed max_width, they are grouped into buckets."""
+    # 90 runs, all failing → 30 buckets, each 1.0
+    base = datetime(2025, 6, 1)
+    tl = [
+        RunResult(base + timedelta(minutes=i), "", "ci", True)
+        for i in range(90)
+    ]
+    buckets = _bucket_timeline(tl, 30)
+    assert len(buckets) == 30
+    assert all(b == 1.0 for b in buckets)
+
+
+def test_bucket_timeline_mixed_large():
+    """Buckets with a mix of pass/fail show intermediate ratios."""
+    # 60 runs: first 30 fail, last 30 pass → bucket into 30 columns
+    base = datetime(2025, 6, 1)
+    tl = [
+        RunResult(base + timedelta(minutes=i), "", "ci", i < 30)
+        for i in range(60)
+    ]
+    buckets = _bucket_timeline(tl, 30)
+    assert len(buckets) == 30
+    # First 15 buckets should be 1.0 (all fail), last 15 should be 0.0 (all pass)
+    assert all(b == 1.0 for b in buckets[:15])
+    assert all(b == 0.0 for b in buckets[15:])
+
+
+def test_render_timeline_human_bucketed():
+    """When timeline exceeds MAX_TIMELINE_WIDTH, output is bucketed and shows run count."""
+    base = datetime(2025, 6, 1)
+    tl = [
+        RunResult(base + timedelta(minutes=i), "", "ci", i % 3 == 0)
+        for i in range(60)
+    ]
+    result = render_timeline_human(tl)
+    # Should be capped at MAX_TIMELINE_WIDTH columns
+    assert result.count("▅") == MAX_TIMELINE_WIDTH
+    # Should show total run count
+    assert "(60 runs)" in result
+
+
+def test_render_timeline_slack_bucketed():
+    """When timeline exceeds MAX_TIMELINE_WIDTH, Slack output is bucketed and shows run count."""
+    base = datetime(2025, 6, 1)
+    tl = [
+        RunResult(base + timedelta(minutes=i), "", "ci", i % 3 == 0)
+        for i in range(60)
+    ]
+    result = render_timeline_slack(tl)
+    # Count emoji characters (🔴, 🟢, 🟡)
+    emoji_count = sum(1 for c in result if c in "🔴🟢🟡")
+    assert emoji_count == MAX_TIMELINE_WIDTH
+    # Should show total run count
+    assert "(60 runs)" in result
+
+
+def test_render_timeline_slack_no_label_when_small():
+    """When timeline fits within MAX_TIMELINE_WIDTH, no run count label is added."""
+    tl = [
+        RunResult(datetime(2025, 6, 1, i), "", "ci", False)
+        for i in range(5)
+    ]
+    result = render_timeline_slack(tl)
+    assert "runs)" not in result
+    assert result == "🟢🟢🟢🟢🟢"
+
+
+def test_render_timeline_slack_yellow_mixed():
+    """Buckets with ~50/50 pass/fail should show yellow 🟡."""
+    # 60 runs alternating fail/pass → each 2-run bucket has 1 fail + 1 pass = 0.5 ratio → yellow
+    base = datetime(2025, 6, 1)
+    tl = [
+        RunResult(base + timedelta(minutes=i), "", "ci", i % 2 == 0)
+        for i in range(60)
+    ]
+    result = render_timeline_slack(tl)
+    assert "🟡" in result
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__, "-v"])
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
### Type of Change

- Enhancement / new feature

### Description

Add flakiness detection (fail-after-pass) and visual timeline

The script previously only collected failing test annotations and ranked them by occurrence count. It had no way to distinguish between **consistently broken tests** (always red) and **truly flaky tests** (alternating green/red). Both were reported the same way.

This PR extends the script to produce **two separate ranked lists** and adds a **visual timeline** for each flaky test.

💡 Let's discuss it

### How to test

- code check
- run it locally to the the cli output
- check the test Slack output on [#temp-test-detect-flakiness](https://staffbasehq.slack.com/archives/C0AHYTN9599)
  - with the [frontend](https://github.com/Staffbase/frontend/pull/17410) and [backend](https://github.com/Staffbase/backend/pull/22062) test PRs

### Example output (terminal)

```
Most failing tests (top 3, limit=12):
  8x (100%) e2e/checkout.spec.ts
  5x (50%) src/auth/login.spec.ts
  2x (20%) src/dashboard/widget.spec.ts

Most flaky tests (top 3, limit=12):
  30% flaky (3 flips / 10 runs) src/auth/login.spec.ts
    ▅▅▅▅▅▅▅▅▅▅          ← red/green alternating (ANSI colored)
  10% flaky (1 flips / 10 runs) src/dashboard/widget.spec.ts
    ▅▅▅▅▅▅▅▅▅▅          ← mostly green, one red blip
  0% flaky (0 flips / 8 runs) e2e/checkout.spec.ts
    ▅▅▅▅▅▅▅▅            ← solid red — broken, not flaky
```

### Example output (Slack)

```
30% flaky (3 flips / 10 runs) `src/auth/login.spec.ts`
    🔴🟢🔴🔴🟢🔴🟢🟢🔴🟢
```

When many runs (e.g. 100+ over a week), the timeline auto-buckets:
```
25% flaky (12 flips / 100 runs) `src/auth/login.spec.ts`
    🟢🟡🔴🟢🟢🟡🔴🟢🟡🟢🔴🟢🟢🟡🔴🟢🟡🟢🟢🔴🟢🟡🔴🟢🟡🟢🔴🟢🟡🟢 _(100 runs)_
```

```
🔄 Top 6 flaky tests — green → red flips (limit=10)
19% flaky (15 flips / 80 runs) src/modules/search/search-results.spec.ts 
    🟡🟡🔴🟢🟡🟡🟡🔴🟢🟡🟡🟡🟢🟡🟡🟡🔴🟡🟢🟡🟡🟡🟡🟡🟡🟢🟡🟡🟡🟢 (80 runs)
        
14% flaky (11 flips / 80 runs) src/modules/auth/login.spec.ts 
    🟢🟡🟢🔴🟢🟢🔴🟢🟢🟢🟢🟡🟢🟢🟡🟢🟡🟢🟡🟢🟡🟢🟢🟢🟢🟡🟢🟢🟡🟡 (80 runs)

10% flaky (8 flips / 80 runs) src/components/navigation/sidebar.spec.ts 
    🟢🟢🟢🟡🟢🟢🟢🟡🟡🟢🟡🟢🟡🟡🟢🟢🟢🟢🟢🟡🟢🟡🟢🟢🟢🟢🟢🟢🟢🟢 (80 runs)

6% flaky (5 flips / 80 runs) src/components/dashboard/widget.spec.tsx 
    🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟡🟢🟢🟢🟡🟢🟢🟢🟢🟢🟡🟢🟢🟢🟢🟢🟢🟢 (80 runs)

4% flaky (3 flips / 80 runs) src/modules/settings/profile.spec.tsx 
    🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢 (80 runs)

0% flaky (0 flips / 80 runs) e2e/flows/checkout.spec.ts.     
    🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴🔴 (80 runs)
Legend: 🟢 = mostly pass · 🔴 = mostly fail · 🟡 = mixed (oldest → newest)
 
The key things visible in the screenshot:
Top list: checkout.spec.ts is #1 with 80 failures — always broken
Bottom list: search-results.spec.ts is #1 flaky with 15 flips — while checkout.spec.ts is dead last (0 flips, solid 🔴) because it never passes, so it's broken, not flaky
The timeline stripes make it immediately visual which tests are flickering vs consistently red
```

